### PR TITLE
Add getters for height and width on resizestep

### DIFF
--- a/src/Config/Steps/ResizeStep.php
+++ b/src/Config/Steps/ResizeStep.php
@@ -47,6 +47,14 @@ class ResizeStep extends VariantStep
 
         return $this;
     }
+    
+    /**
+     * @return int
+     */
+    public function getWidth()
+    {
+        return $this->width;
+    }
 
     /**
      * @param int $pixels
@@ -57,6 +65,14 @@ class ResizeStep extends VariantStep
         $this->height = $pixels;
 
         return $this;
+    }
+    
+    /**
+     * @return int
+     */
+    public function getHeight()
+    {
+        return $this->height;
     }
 
     /**


### PR DESCRIPTION
To support srcsets, I need the width of the variant.

For example:
```blade
<picture>
    @foreach($attachment->image->getConfig()['variants'] as $variant)
        <source
              srcset="{{ $teaserImage->image->url($variant->getName()) }}"
              media="(max-width: {{ $variant->getSteps()[0]->getWidth() }}px)"
        >
    @endforeach
    <img src="{{ $teaserImage->image->url('max') }}" alt="#">
</picture>
```