### PR TITLE
Using array_key_exists() on objects is deprecated.

### DIFF
--- a/src/Config/VariantList.php
+++ b/src/Config/VariantList.php
@@ -131,7 +131,7 @@ class VariantList
             $options = [ $options ];
         }
 
-        if (array_key_exists('dimensions', $options)) {
+        if (property_exists($options, 'dimensions')) {
             $options = [
                 'resize' => $options,
             ];


### PR DESCRIPTION
Using array_key_exists() on objects is deprecated as of PHP 7.4