### PR TITLE
Make PaperclipTrait::setAttribute fluent to match the behaviour of its parent

### DIFF
--- a/src/Model/PaperclipTrait.php
+++ b/src/Model/PaperclipTrait.php
@@ -127,6 +127,7 @@ trait PaperclipTrait
      *
      * @param string $key
      * @param mixed  $value
+     * @return mixed
      */
     public function setAttribute($key, $value)
     {
@@ -137,7 +138,7 @@ trait PaperclipTrait
 
                 if ($value === $this->getDeleteAttachmentString()) {
                     $attachedFile->setToBeDeleted();
-                    return;
+                    return $this;
                 }
 
                 /** @var StorableFileFactoryInterface $factory */
@@ -150,10 +151,10 @@ trait PaperclipTrait
 
             $this->attachedUpdated = true;
 
-            return;
+            return $this;
         }
 
-        parent::setAttribute($key, $value);
+        return parent::setAttribute($key, $value);
     }
 
     /**


### PR DESCRIPTION
The original `HasAttributes::setAttribute` is fluent and some of Laravel's code depends on that fact. Overriding this methods without this fluency can break an application. This PR fixes that.

https://github.com/laravel/framework/blob/8734c47fff3fe51cd80d48cfde65bedfbc14a81f/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php#L907