### PR TITLE
Extract attachment instance creation in factory to improve extendibility

### DIFF
--- a/src/Attachment/AttachmentFactory.php
+++ b/src/Attachment/AttachmentFactory.php
@@ -23,7 +23,7 @@ class AttachmentFactory implements AttachmentFactoryInterface
      */
     public function create(AttachableInterface $instance, string $name, array $config = []): AttachmentInterface
     {
-        $attachment = new Attachment;
+        $attachment = $this->createInstance();
 
         $configObject = $this->makeConfigObject($config);
 
@@ -34,6 +34,11 @@ class AttachmentFactory implements AttachmentFactoryInterface
         $attachment->setStorage($configObject->storageDisk());
 
         return $attachment;
+    }
+
+    protected function createInstance(): AttachmentInterface
+    {
+        return new Attachment();
     }
 
     /**


### PR DESCRIPTION
Recently I wanted to extend the `Attachment` class which meant I also had to extend the `AttachmentFactory` class. This resulted in the following code:
```php
use Czim\Paperclip\Attachment\AttachmentFactory as Factory;
use My\Own\Custom\Attachment;

class AttachmentFactory extends Factory
{
    public function create(AttachableInterface $instance, string $name, array $config = []): AttachmentInterface
    {
        $attachment = new Attachment();

        $configObject = $this->makeConfigObject($config);

        $attachment->setInstance($instance);
        $attachment->setName($name);
        $attachment->setConfig($configObject);
        $attachment->setInterpolator($this->getInterpolator());
        $attachment->setStorage($configObject->storageDisk());

        return $attachment;
    }
}
```
As you can see I had to copy all the setup code, even-though I only wanted to change the attachment class. This PR solves this by having a dedicated method for just creating the instance. This will result in an improved factory extension:
```php
use Czim\Paperclip\Attachment\AttachmentFactory as Factory;
use My\Own\Custom\Attachment;

class AttachmentFactory extends Factory
{
    protected function createInstance(): AttachmentInterface
    {
        return new Attachment();
    }
}
```