### PR TITLE
Patched vulnerability from czim/file-handling package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Laravel 9 and up
 
+### [5.0.1] - 2024-09-10
+
+Patched vulnerability from czim/file-handling package
+
 ### [5.0.0] - 2022-10-31
 
 There are quite a few breaking changes:
@@ -207,6 +211,7 @@ See 2.5.2.
 
 This merges the changes for 2.5.0 and 2.5.1 in a new major version for Laravel 5.4 and earlier.
 
+[5.0.1]: https://github.com/czim/laravel-paperclip/compare/5.0.0...5.0.1
 [5.0.0]: https://github.com/czim/laravel-paperclip/compare/4.0.1...5.0.0
 
 [4.0.1]: https://github.com/czim/laravel-paperclip/compare/4.0.0...4.0.1

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "homepage": "https://github.com/czim",
     "require": {
         "php": "^8.1",
-        "czim/file-handling": "^2.0",
+        "czim/file-handling": "^2.2.1",
         "ext-json": "*"
     },
     "require-dev": {


### PR DESCRIPTION
Patches [this issue](https://github.com/czim/file-handling/blob/2.2.1/CHANGELOG.md#221---2024-09-10) from czim/file-handling package.

Tag 5.0.1 is presumed. Let me know if you want to drop that change from the changelog from this MR